### PR TITLE
Dired and terminals

### DIFF
--- a/tango-plus-theme.el
+++ b/tango-plus-theme.el
@@ -502,6 +502,14 @@ Semantic, and Ansi-Color faces are included.")
    `(eshell-ls-executable            ((,class (:foreground ,choc-3))))
    `(eshell-ls-special               ((,class (:foreground ,plum-3))))
 
+   ;;vterm
+   `(vterm-color-black               ((,class (:foreground ,black))))
+   `(vterm-color-red               ((,class (:foreground ,red-3))))
+   `(vterm-color-blue               ((,class (:foreground ,blue-3))))
+   `(vterm-color-green               ((,class (:foreground ,cham-3))))
+   `(vterm-color-yellow               ((,class (:foreground ,butter-3))))
+   `(vterm-color-magenta               ((,class (:foreground ,plum-3))))
+   `(vterm-color-cyan               ((,class (:foreground ,blue-1))))
    )
 
   (custom-theme-set-variables

--- a/tango-plus-theme.el
+++ b/tango-plus-theme.el
@@ -119,6 +119,8 @@ Semantic, and Ansi-Color faces are included.")
    `(success                        ((,class (:foreground ,cham-3))))
    `(show-paren-match               ((,class (:inherit highlight))))
    `(show-paren-mismatch            ((,class (:inherit trailing-whitespace))))
+   `(sh-quoted-exec                 ((,class (:foreground, black))))
+   `(sh-heredoc                     ((,class (:foreground, black))))
 
    ;; Tango-plus faces:
    `(tango-plus-deemphasized        ((,class (:foreground ,alum-4))))

--- a/tango-plus-theme.el
+++ b/tango-plus-theme.el
@@ -495,6 +495,13 @@ Semantic, and Ansi-Color faces are included.")
    `(dired-async-message                ((,class (:foreground ,butter-1 :weight bold))))
    `(dired-async-mode-message           ((,class (:foreground ,butter-1))))
 
+   ;;eshell
+   `(eshell-prompt                   ((,class (:foreground ,blue-3))))
+   `(eshell-ls-directory             ((,class (:weight bold :foreground ,black))))
+   `(eshell-ls-symlink               ((,class (:weight bold :foreground ,butter-3))))
+   `(eshell-ls-executable            ((,class (:foreground ,choc-3))))
+   `(eshell-ls-special               ((,class (:foreground ,plum-3))))
+
    )
 
   (custom-theme-set-variables

--- a/tango-plus-theme.el
+++ b/tango-plus-theme.el
@@ -75,7 +75,7 @@ Semantic, and Ansi-Color faces are included.")
       ;; Not in Tango palette; used for better contrast.
       (white "#ffffff") (black "#000000") (plum-0 "#edc4e2")
       (red-0 "#ffe6e6") (red-4 "#ff2d2d")(cham-0 "#e6ffc2")
-      (cham-4 "#346604") (blue-0 "#8cc4ff" ) (orange-4 "#b35000"))
+      (cham-4 "#346604") (blue-0 "#8cc4ff") (orange-4 "#b35000"))
 
   (custom-theme-set-faces
    'tango-plus
@@ -438,6 +438,62 @@ Semantic, and Ansi-Color faces are included.")
    `(doom-modeline-evil-visual-state    ((,class (:weight bold
 		 			          :foreground ,butter-1))))
    `(doom-modeline-buffer-modified      ((,class (:inherit doom-modeline-urgent))))
+
+   ;; dired
+   `(diredp-display-msg                 ((,class (:foreground ,blue-0))))
+   `(diredp-compressed-file-suffix      ((,class (:foreground ,butter-1))))
+   `(diredp-date-time                   ((,class (:foreground ,choc-3))))
+   `(diredp-deletion                    ((,class (:foreground ,butter-1))))
+   `(diredp-deletion-file-name          ((,class (:foreground ,red-1))))
+   `(diredp-dir-heading                 ((,class (:foreground ,blue-3 :background ,alum-2))))
+   `(diredp-dir-priv                    ((,class (:foreground ,blue-3))))
+   `(diredp-exec-priv                   ((,class (:foreground ,red-1))))
+   `(diredp-executable-tag              ((,class (:foreground ,cham-1))))
+   `(diredp-file-name                   ((,class (:foreground ,black))))
+   `(diredp-file-suffix                 ((,class (:foreground ,red-2))))
+   `(diredp-flag-mark                   ((,class (:foreground ,butter-1))))
+   `(diredp-flag-mark-line              ((,class (:foreground ,orange-1))))
+   `(diredp-ignored-file-name           ((,class (:foreground ,alum-6))))
+   `(diredp-link-priv                   ((,class (:foreground ,butter-1))))
+   `(diredp-mode-line-flagged           ((,class (:foreground ,butter-1))))
+   `(diredp-mode-line-marked            ((,class (:foreground ,orange-1))))
+   `(diredp-no-priv                     ((,class (:foreground ,white))))
+   `(diredp-number                      ((,class (:foreground ,red-0))))
+   `(diredp-other-priv                  ((,class (:foreground ,butter-1))))
+   `(diredp-rare-priv                   ((,class (:foreground ,red-3))))
+   `(diredp-read-priv                   ((,class (:foreground ,butter-3))))
+   `(diredp-symlink                     ((,class (:foreground ,butter-1))))
+   `(diredp-write-priv                  ((,class (:foreground ,plum-1))))
+
+   ;; diredfl
+   `(diredfl-compressed-file-name       ((,class (:foreground ,alum-1 :weight bold))))
+   `(diredfl-compressed-file-suffix     ((,class (:inherit diredfl-compressed-file-name))))
+   `(diredfl-dir-name                   ((,class (:foreground ,alum-6 :weight bold))))
+   `(diredfl-date-time                  ((,class (:foreground ,choc-3))))
+   `(diredfl-deletion                   ((,class (:foreground ,butter-1))))
+   `(diredfl-deletion-file-name         ((,class (:foreground ,red-3))))
+   `(diredfl-dir-heading                ((,class (:foreground ,black :background ,alum-2))))
+   `(diredfl-dir-priv                   ((,class (:foreground ,black :weight bold))))
+   `(diredfl-exec-priv                  ((,class (:foreground ,blue-3))))
+   `(diredfl-executable-tag             ((,class (:foreground ,blue-3))))
+   `(diredfl-file-name                  ((,class (:foreground ,black))))
+   `(diredfl-file-suffix                ((,class (:inherit 'diredfl-file-name))))
+   `(diredfl-flag-mark                  ((,class (:foreground ,butter-1))))
+   `(diredfl-flag-mark-line             ((,class (:foreground ,orange-1))))
+   ;;`(diredfl-ignored-file-name          ((,class (:foreground ,alum-2))))
+   `(diredfl-link-priv                  ((,class (:foreground ,butter-1))))
+   `(diredfl-no-priv                    ((,class (:foreground ,white))))
+   `(diredfl-number                     ((,class (:foreground ,red-3)))) ;;n files in folder and size
+   `(diredfl-other-priv                 ((,class (:foreground ,butter-1))))
+   `(diredfl-rare-priv                  ((,class (:foreground ,blue-3))))
+   `(diredfl-read-priv                  ((,class (:foreground ,black))))
+   `(diredfl-symlink                    ((,class (:foreground ,plum-3))))
+   `(diredfl-write-priv                 ((,class (:foreground ,black))))
+
+   ;; dired-async
+   `(dired-async-failures               ((,class (:foreground ,red-3 :weight bold))))
+   `(dired-async-message                ((,class (:foreground ,butter-1 :weight bold))))
+   `(dired-async-mode-message           ((,class (:foreground ,butter-1))))
 
    )
 


### PR DESCRIPTION
Lately I was working a lot with tango-plus, since I really like the theme. 
This commit  is holding the faces for some modes I was missing.

What do you think?

## Changes in shell
old:
![shell-old](https://user-images.githubusercontent.com/52403389/156133371-e51663b4-9d1c-42c0-96af-27cd7630022c.png)

new:
![shell-new](https://user-images.githubusercontent.com/52403389/156133352-1d75380d-c552-4a6b-bb17-552753f9bf09.png)

## Changes in dired
old:
![dired-old](https://user-images.githubusercontent.com/52403389/156133687-03413e66-31fe-4553-8209-5757caba3236.png)

new:
![dired-new](https://user-images.githubusercontent.com/52403389/156133771-d70fb945-8a7a-45cd-997f-13b6d77228cd.png)

## Changes in vterm
old:
![vterm-old](https://user-images.githubusercontent.com/52403389/156133844-2e2e9589-67c0-4a7d-b69b-9059fa75e9f7.png)

new:
![vterm-new](https://user-images.githubusercontent.com/52403389/156133875-c2664aa8-407c-44c7-b2fc-4ca76204d4a7.png)

- Yes,  folders are now represented in vterm differently than in eshell and dired. But vterm faces are linked to colors (e.g. `vterm-color-yellow`) and not elements. I don't wanted to link a vterm-color e.g. `vterm-color-yellow` to a different color in order to make the folders correct. I found that not intuitive. Feel free to change..

## Changes in eshell
old:
![eshell-old](https://user-images.githubusercontent.com/52403389/156133974-500716bd-71a1-4a0d-9c1e-fbfb044f6512.png)

new:
![eshell-new](https://user-images.githubusercontent.com/52403389/156133998-9c7a3011-c22e-4195-b272-27e4d67a6d63.png)


