### PR TITLE
Remove the customization for the `cursor` face

### DIFF
--- a/tango-plus-theme.el
+++ b/tango-plus-theme.el
@@ -110,7 +110,6 @@ Semantic, and Ansi-Color faces are included.")
    `(fringe                         ((,class (:foreground ,alum-2
 					      :background ,white))))
    ;; Skipping `scroll-bar', `border'.
-   `(cursor                         ((,class (:inverse-video t))))
    ;; Skipping `mouse', `tool-bar', `menu'.
    ;; FIXME `help-argument-name'
    ;; Skipping `glyphless-char'.


### PR DESCRIPTION
It's normally a no-op (the cursor already looks like that), but it can also trigger a bug in certain circumstances:

https://debbugs.gnu.org/71866